### PR TITLE
Feature/add timeout issue 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019-2020  SenX S.A.S.
+//   Copyright 2019-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,9 @@ test {
   useJUnit()
 }
 
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
 sourceSets {
   main {
     compileClasspath = compileClasspath + configurations.provided

--- a/src/main/java/io/warp10/script/ext/influxdb/HttpClientUtils.java
+++ b/src/main/java/io/warp10/script/ext/influxdb/HttpClientUtils.java
@@ -1,0 +1,49 @@
+//
+//   Copyright 2021  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.ext.influxdb;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import io.warp10.script.WarpScriptException;
+import okhttp3.OkHttpClient.Builder;
+
+public class HttpClientUtils {
+
+    private static final String KEY_READ_TIMEOUT = "readTimeout";
+    private static final String KEY_WRITE_TIMEOUT = "writeTimeout";
+
+    public static Builder getOkHttpClientBuilder(final String functionName, final Map<Object, Object> params) throws WarpScriptException {
+
+        Builder result = new Builder();
+        result.readTimeout(getLongValueFromKey(functionName, params, KEY_READ_TIMEOUT, result.getReadTimeout$okhttp()), TimeUnit.MILLISECONDS);
+        result.writeTimeout(getLongValueFromKey(functionName, params, KEY_WRITE_TIMEOUT, result.getWriteTimeout$okhttp()), TimeUnit.MILLISECONDS);
+
+        return result;
+    }
+
+    private static long getLongValueFromKey(final String functionName, final Map<Object, Object> params, final String key, final long defaultValue) throws WarpScriptException {
+
+        Object value = params.getOrDefault(key, defaultValue);
+        if (!(value instanceof Long)) {
+            throw new WarpScriptException(functionName + " expects a Long value for the " + key + " parameter.");
+        }
+
+        return (long) value;
+    }
+
+}

--- a/src/main/warpscript/io.warp10/warp10-ext-influxdb/INFLUXDB.FETCH.mc2
+++ b/src/main/warpscript/io.warp10/warp10-ext-influxdb/INFLUXDB.FETCH.mc2
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020  SenX S.A.S.
+//   Copyright 2020-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ The parameter map must contain the following entries:
 | `user` | User used for authentification. |
 | `password` | Password associated with `user`. |
 | `influxql` | [InfluxQL](https://docs.influxdata.com/influxdb/v1.8/query_language/) queries, separated by semi-colons. Queries should contain a GROUP BY clause otherwise tags will be interpreted as fields and produce GTS of their own. |
+| `readTimeout` | Read timeout used to execute read InfluxDB queries (in milliseconds). Optional - Default value from [OkHttp lib](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/read-timeout/). |
+| `writeTimeout` | Write timeout used to execute write InfluxDB queries (in milliseconds). Optional - Default value from [OkHttp lib](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/write-timeout/). |
 
     '>
   'sig' [

--- a/src/main/warpscript/io.warp10/warp10-ext-influxdb/INFLUXDB.FLUX.mc2
+++ b/src/main/warpscript/io.warp10/warp10-ext-influxdb/INFLUXDB.FLUX.mc2
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020  SenX S.A.S.
+//   Copyright 2020-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ The parameter map must contain the following entries:
 | `token` | Access token to use for connection to InfluxDB. |
 | `org` |  Organization to use. |
 | `flux` | Flux query to execute. |
+| `readTimeout` | Read timeout used to execute read InfluxDB queries (in milliseconds). Optional - Default value from [OkHttp lib](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/read-timeout/). |
+| `writeTimeout` | Write timeout used to execute write InfluxDB queries (in milliseconds). Optional - Default value from [OkHttp lib](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/write-timeout/). |
 
 The results returned by flux each contain a table id, this table id is inserted as the value of special label `_table` in the returned Geo Time Series. If a series already contains a label `_table`, extra leading underscores will be added until no such label exists.
     '>

--- a/src/main/warpscript/io.warp10/warp10-ext-influxdb/INFLUXDB.UPDATE.mc2
+++ b/src/main/warpscript/io.warp10/warp10-ext-influxdb/INFLUXDB.UPDATE.mc2
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020  SenX S.A.S.
+//   Copyright 2020-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ The parameter map must contain the following entries:
 | `org` | `2.x` only, organization to use. |
 | `bucket` | `2.x` only, bucket to use for storing the data. |
 | `batchsize` | `2.x` only. Number of points to batch in a single call to the backend. Maximum value is 10000, defaults to 5000. |
+| `readTimeout` | Read timeout used to execute read InfluxDB queries (in milliseconds). Optional - Default value from [OkHttp lib](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/read-timeout/). |
+| `writeTimeout` | Write timeout used to execute write InfluxDB queries (in milliseconds). Optional - Default value from [OkHttp lib](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/write-timeout/). |
 
 For InfluxDB `2.x`, when storing a point which has a location, fields `lat` and `lon` will be set automatically. If the point has an elevation, field `elev` will be set automatically.
     '>


### PR DESCRIPTION
#2 This is my contribution to manage read and write timeout when influxdb queries are executed.

There are 2 new optionals parameters in the parameters Map : 
- `readTimeout` which is a long value ;
- `writeTimeout` which is a long value.

I modified the `FETCH`, `FLUX` and `UPDATE` functions to take into account this new params.